### PR TITLE
feat: restore n5 writer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.java]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ on: [push]
 
 env:
   REGISTRY: docker.pkg.github.com
-  IMAGE: keeneyetech/bioformats2raw/bioformats2raw
+  IMAGE: keeneyetech/bioformats2n5/bioformats2n5
 
 jobs:
   build:
@@ -49,6 +49,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: build/distributions/bioformats2raw*.zip
+          files: build/distributions/bioformats2n5*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .*.swp
 build
 .gradle
+.idea

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Usage
 
 Run the conversion:
 
-    bioformats2n5 /path/to/file.mrxs /path/to/zarr-pyramid --resolutions 6
-    bioformats2n5 /path/to/file.svs /path/to/zarr-pyramid --resolutions 6
+    bioformats2n5 /path/to/file.mrxs /path/to/n5-pyramid --resolutions 6
+    bioformats2n5 /path/to/file.svs /path/to/n5-pyramid --resolutions 6
 
 Maximum tile dimensions are can be configured with the `--tile_width` and `--tile_height` options.  Defaults can be viewed with
 `bioformats2n5 --help`.  `--resolutions` is optional; if omitted, the number of resolutions is set so that the smallest
@@ -51,51 +51,44 @@ resolution is no greater than 256x256.
 
 If the input file has multiple series, a subset of the series can be converted by specifying a comma-separated list of indexes:
 
-    bioformats2n5 /path/to/file.scn /path/to/zarr-pyramid --series 0,2,3,4
+    bioformats2n5 /path/to/file.scn /path/to/n5-pyramid --series 0,2,3,4
 
 By default, two additional readers (MiraxReader and PyramidTiffReader) are added to the beginning of Bio-Formats' list of reader classes.
 Either or both of these readers can be excluded with the `--extra-readers` option:
 
     # only include the reader for .mrxs, exclude the reader for Faas pyramids
-    bioformats2n5 /path/to/file.tiff /path/to/zarr-pyramid --extra-readers MiraxReader
+    bioformats2n5 /path/to/file.tiff /path/to/n5-pyramid --extra-readers MiraxReader
     # don't add any additional readers, just use the ones provided by Bio-Formats
-    bioformats2n5 /path/to/file.mrxs /path/to/zarr-pyramid --extra-readers
+    bioformats2n5 /path/to/file.mrxs /path/to/n5-pyramid --extra-readers
 
 Reader-specific options can be specified using `--options`:
 
-    bioformats2n5 /path/to/file.mrxs /path/to/zarr-pyramid --options mirax.use_metadata_dimensions=false
+    bioformats2n5 /path/to/file.mrxs /path/to/n5-pyramid --options mirax.use_metadata_dimensions=false
 
 Be aware when experimenting with different values for `--options` that the corresponding memo (cache) file may need to be
 removed in order for new options to take effect.  This file will be e.g. `/path/to/.file.mrxs.bfmemo`.
 
-The output in `/path/to/zarr-pyramid` can be passed to `raw2ometiff` to produce
+The output in `/path/to/n5-pyramid` can be passed to `raw2ometiff` to produce
 an OME-TIFF that can be opened in ImageJ, imported into OMERO, etc. See
 https://github.com/glencoesoftware/raw2ometiff for more information.
 
 Usage Changes
 =============
 
-Versions 0.2.6 and prior supported both N5 and Zarr output using the `--file_type` option.
-This option is not present in 0.3.0 and later, as only Zarr output is supported.
-
 Versions 0.2.6 and prior used the input file's dimension order to determine the output
 dimension order, unless `--dimension-order` was specified.
 Version 0.3.0 uses the `TCZYX` order by default, for compatibility with https://ngff.openmicroscopy.org/0.2/#image-layout.
 The `--dimension-order` option can still be used to set a specific output dimension order, e.g.:
 
-    bioformats2n5 /path/to/file.mrxs /path/to/zarr-pyramid --dimension-order XYCZT
+    bioformats2n5 /path/to/file.mrxs /path/to/n5-pyramid --dimension-order XYCZT
 
 or can be set to use the input file's ordering, preserving the behavior of 0.2.6:
 
-    bioformats2n5 /path/to/file.mrxs /path/to/zarr-pyramid --dimension-order original
+    bioformats2n5 /path/to/file.mrxs /path/to/n5-pyramid --dimension-order original
 
 If a specific dimension order is passed to `--dimension-order`, it must be a valid dimension order as defined in
 the [OME 2016-06 schema](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Pixels_DimensionOrder).
 The specified dimension order is then reversed when creating Zarr arrays, e.g. `XYCZT` would become `TZCYX` in Zarr.
-
-Prior to version 0.3.0, N5/Zarr output was placed in a subdirectory (`data.[n5|zarr]`) with a `METADATA.ome.xml` file
-at the same level.  As of 0.3.0 the desired output directory is now a Zarr group and the `METADATA.ome.xml` file is
-placed in a `OME` directory within.  These changes reflect layout version 3.
 
 Performance
 ===========

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,15 @@ dependencies {
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'com.univocity:univocity-parsers:2.8.4'
     implementation 'com.bc.zarr:jzarr:0.3.3-gs-SNAPSHOT'
+    implementation 'org.janelia.saalfeldlab:n5:2.2.0'
+
+    // exclude JUnit 4 to make sure our tests all use JUnit 5
+    implementation('org.janelia.saalfeldlab:n5-blosc:1.1.0') {
+        exclude group: 'junit', module: 'junit'
+    }
+    implementation('org.janelia.saalfeldlab:n5-zarr:0.0.4') {
+        exclude group: 'junit', module: 'junit'
+    }
 
     implementation 'org.openpnp:opencv:3.4.2-1'
     implementation 'me.tongfei:progressbar:0.9.0'

--- a/src/main/java/ai/keeneye/bioformats2n5/FileType.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/FileType.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2019 Glencoe Software, Inc. All rights reserved.
+ *
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package ai.keeneye.bioformats2n5;
+
+import java.io.IOException;
+
+import org.janelia.saalfeldlab.n5.N5FSReader;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
+import org.janelia.saalfeldlab.n5.zarr.N5ZarrWriter;
+
+/**
+ * Enumeration that backs the --file_type flag. Instances can be used
+ * as a factory method to create {@link N5Reader} and {@link N5Writer}
+ * instances.
+ */
+public enum FileType {
+  n5 {
+    N5Reader reader(String path) throws IOException {
+      return new N5FSReader(path);
+    }
+    N5Writer writer(String path) throws IOException {
+      return new N5FSWriter(path);
+    }
+  },
+  zarr {
+    N5Reader reader(String path) throws IOException {
+      return new N5ZarrReader(path);
+    }
+    N5Writer writer(String path) throws IOException {
+      return new N5ZarrWriter(path);
+    }
+  };
+  abstract N5Reader reader(String path) throws IOException;
+  abstract N5Writer writer(String path) throws IOException;
+}

--- a/src/main/java/ai/keeneye/bioformats2n5/ZarrCompression.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/ZarrCompression.java
@@ -8,19 +8,70 @@
 package ai.keeneye.bioformats2n5;
 
 
-public enum ZarrCompression {
-  raw("null"),
-  zlib("zlib"),
-  blosc("blosc");
+import org.janelia.saalfeldlab.n5.Bzip2Compression;
+import org.janelia.saalfeldlab.n5.Compression;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.Lz4Compression;
+import org.janelia.saalfeldlab.n5.RawCompression;
+import org.janelia.saalfeldlab.n5.XzCompression;
+import org.janelia.saalfeldlab.n5.blosc.BloscCompression;
 
-  private final String value;
+public class ZarrCompression {
+  enum CompressionTypes { blosc, bzip2, gzip, lz4, raw, xz };
 
-  private ZarrCompression(final String value) {
-    this.value = value;
-  }
-
-  @Override
-  public String toString() {
-    return value;
+  /**
+   * Get an N5/zarr compressor for the given compression type.
+   *
+   * @param type compression type
+   * @param compressionParameter type-specific parameter (may be null)
+   * @return Compression object that can compress data, or null if
+  the compression type is not recognized
+   */
+  public static Compression getCompressor(
+    ZarrCompression.CompressionTypes type,
+    Integer compressionParameter)
+  {
+    switch (type) {
+      case blosc:
+        return new BloscCompression(
+          "lz4",
+          5, // clevel
+          BloscCompression.SHUFFLE,  // shuffle
+          0, // blocksize (0 = auto)
+          1  // nthreads
+        );
+      case gzip:
+        if (compressionParameter == null) {
+          return new GzipCompression();
+        }
+        else {
+          return new GzipCompression(compressionParameter.intValue());
+        }
+      case bzip2:
+        if (compressionParameter == null) {
+          return new Bzip2Compression();
+        }
+        else {
+          return new Bzip2Compression(compressionParameter.intValue());
+        }
+      case xz:
+        if (compressionParameter == null) {
+          return new XzCompression();
+        }
+        else {
+          return new XzCompression(compressionParameter.intValue());
+        }
+      case lz4:
+        if (compressionParameter == null) {
+          return new Lz4Compression();
+        }
+        else {
+          return new Lz4Compression(compressionParameter.intValue());
+        }
+      case raw:
+        return new RawCompression();
+      default:
+        return null;
+    }
   }
 }

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -1,0 +1,584 @@
+/**
+ * Copyright (c) 2019 Glencoe Software, Inc. All rights reserved.
+ * <p>
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
+package ai.keeneye.bioformats2n5.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ShortBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import ai.keeneye.bioformats2n5.Converter;
+import ai.keeneye.bioformats2n5.Downsampling;
+import loci.common.LogbackTools;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatTools;
+import loci.formats.in.FakeReader;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.OMEXMLService;
+import org.janelia.saalfeldlab.n5.N5FSReader;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import picocli.CommandLine;
+import picocli.CommandLine.ExecutionException;
+
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opencv.core.Core;
+
+public class N5Test {
+
+  Path input;
+
+  Path output;
+
+  Converter converter;
+
+  /**
+   * Set logging to warn before all methods.
+   *
+   * @param tmp temporary directory for output file
+   */
+  @BeforeEach
+  public void setup(@TempDir Path tmp) throws Exception {
+    output = tmp.resolve("test");
+    LogbackTools.setRootLevel("warn");
+  }
+
+  /**
+   * Run the Converter main method and check for success or failure.
+   *
+   * @param additionalArgs CLI arguments as needed beyond "-o output input"
+   */
+  void assertTool(String... additionalArgs) throws IOException {
+    List<String> args = new ArrayList<String>();
+    for (String arg : additionalArgs) {
+      args.add(arg);
+    }
+    args.add("--file_type=n5");
+    args.add(input.toString());
+    args.add(output.toString());
+    try {
+      converter = new Converter();
+      CommandLine.call(converter, args.toArray(new String[]{}));
+      assertTrue(Files.exists(output.resolve("data.n5")));
+      assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
+    }
+    catch (RuntimeException rt) {
+      throw rt;
+    }
+    catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  static Path fake(String... args) {
+    assertTrue(args.length % 2 == 0);
+    Map<String, String> options = new HashMap<String, String>();
+    for (int i = 0; i < args.length; i += 2) {
+      options.put(args[i], args[i + 1]);
+    }
+    return fake(options);
+  }
+
+  static Path fake(Map<String, String> options) {
+    return fake(options, null);
+  }
+
+  /**
+   * Create a Bio-Formats fake INI file to use for testing.
+   * @param options map of the options to assign as part of the fake filename
+   * from the allowed keys
+   * @param series map of the integer series index and options map (same format
+   * as <code>options</code> to add to the fake INI content
+   * @see https://docs.openmicroscopy.org/bio-formats/6.4.0/developers/
+   * generating-test-images.html#key-value-pairs
+   * @return path to the fake INI file that has been created
+   */
+  static Path fake(Map<String, String> options,
+                   Map<Integer, Map<String, String>> series)
+  {
+    return fake(options, series, null);
+  }
+
+  static Path fake(Map<String, String> options,
+                   Map<Integer, Map<String, String>> series,
+                   Map<String, String> originalMetadata)
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("image");
+    if (options != null) {
+      for (Map.Entry<String, String> kv : options.entrySet()) {
+        sb.append("&");
+        sb.append(kv.getKey());
+        sb.append("=");
+        sb.append(kv.getValue());
+      }
+    }
+    sb.append("&");
+    try {
+      List<String> lines = new ArrayList<String>();
+      if (originalMetadata != null) {
+        lines.add("[GlobalMetadata]");
+        for (String key : originalMetadata.keySet()) {
+          lines.add(String.format("%s=%s", key, originalMetadata.get(key)));
+        }
+      }
+      if (series != null) {
+        for (int s : series.keySet()) {
+          Map<String, String> seriesOptions = series.get(s);
+          lines.add(String.format("[series_%d]", s));
+          for (String key : seriesOptions.keySet()) {
+            lines.add(String.format("%s=%s", key, seriesOptions.get(key)));
+          }
+        }
+      }
+      Path ini = Files.createTempFile(sb.toString(), ".fake.ini");
+      File iniAsFile = ini.toFile();
+      String iniPath = iniAsFile.getAbsolutePath();
+      String fakePath = iniPath.substring(0, iniPath.length() - 4);
+      Path fake = Paths.get(fakePath);
+      File fakeAsFile = fake.toFile();
+      Files.write(fake, new byte[]{});
+      Files.write(ini, lines);
+      iniAsFile.deleteOnExit();
+      fakeAsFile.deleteOnExit();
+      return ini;
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Test a fake file with default values smaller than
+   * the default tile size (512 vs 1024).
+   */
+  @Test
+  public void testDefaultIsTooBig() throws Exception {
+    input = fake();
+    assertTool();
+  }
+
+  /**
+   * Test additional format string args.
+   */
+  @Test
+  public void testAdditionalScaleFormatStringArgs() throws Exception {
+    input = fake("series", "2");
+    Path csv = Files.createTempFile(null, ".csv");
+    Files.write(csv, Arrays.asList((new String[]{
+      "abc,888,def",
+      "ghi,999,jkl"
+    })));
+    csv.toFile().deleteOnExit();
+    assertTool(
+      "--scale-format-string", "%3$s/%4$s/%1$s/%2$s",
+      "--additional-scale-format-string-args", csv.toString()
+    );
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    assertTrue(z.exists("/abc/888/0/0"));
+    assertTrue(z.exists("/ghi/999/1/0"));
+  }
+
+  /**
+   * Test a fake file conversion and ensure the layout is set.
+   */
+  @Test
+  public void testDefaultLayoutIsSet() throws Exception {
+    input = fake();
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    Integer layout =
+      z.getAttribute("/", "bioformats2n5.layout", Integer.class);
+    assertEquals(Converter.LAYOUT, layout);
+  }
+
+  /**
+   * Test that multiscales metadata is present.
+   */
+  @Test
+  public void testMultiscalesMetadata() throws Exception {
+    input = fake();
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    //
+    List<Map<String, Object>> multiscales =
+      z.getAttribute("/0", "multiscales", List.class);
+    assertEquals(1, multiscales.size());
+    Map<String, Object> multiscale = multiscales.get(0);
+    assertEquals("0.2", multiscale.get("version"));
+    List<Map<String, Object>> datasets =
+      (List<Map<String, Object>>) multiscale.get("datasets");
+    assertTrue(datasets.size() > 0);
+    assertEquals("0", datasets.get(0).get("path"));
+  }
+
+  /**
+   * Test alternative dimension order.
+   */
+  @Test
+  public void testXYCZTDimensionOrder() throws Exception {
+    input = fake("sizeC", "2", "dimOrder", "XYCZT");
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 1, 2, 1}, da.getDimensions());
+  }
+
+  /**
+   * Test using a forced dimension order.
+   */
+  @Test
+  public void testSetXYCZTDimensionOrder() throws Exception {
+    input = fake("sizeC", "2");
+    assertTool("--dimension-order", "XYCZT");
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 2, 1, 1}, da.getDimensions());
+  }
+
+  /**
+   * Test using a different tile size from the default (1024).
+   */
+  @Test
+  public void testSetSmallerDefault() throws Exception {
+    input = fake();
+    assertTool("-h", "128", "-w", "128");
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{128, 128, 1, 1, 1}, da.getBlockSize());
+  }
+
+  /**
+   * Test using a different tile size from the default (1024) the does not
+   * divide evenly.
+   */
+  @Test
+  public void testSetSmallerDefaultWithRemainder() throws Exception {
+    input = fake();
+    assertTool("-h", "384", "-w", "384");
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{384, 384, 1, 1, 1}, da.getBlockSize());
+  }
+
+  /**
+   * Test more than one series.
+   */
+  @Test
+  public void testMultiSeries() throws Exception {
+    input = fake("series", "2", "file_type", "n5");
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+
+    // Check series 0 dimensions and special pixels
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{512, 512, 1, 1, 1}, da.getBlockSize());
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[]{0, 0, 0, 0, 0})
+      .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+
+    // Check series 1 dimensions and special pixels
+    da = z.getDatasetAttributes("/1/0");
+    assertArrayEquals(new long[]{512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{512, 512, 1, 1, 1}, da.getBlockSize());
+    tile = z.readBlock("/1/0", da, new long[]{0, 0, 0, 0, 0})
+      .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{1, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+  }
+
+  /**
+   * Test more than one Z-section.
+   */
+  @Test
+  public void testMultiZ() throws Exception {
+    input = fake("sizeZ", "2");
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+
+    // Check dimensions and block size
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 2, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{512, 512, 1, 1, 1}, da.getBlockSize());
+
+    // Check Z 0 special pixels
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[]{0, 0, 0, 0, 0})
+      .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    // Check Z 1 special pixels
+    tile = z.readBlock("/0/0", da, new long[]{0, 0, 1, 0, 0})
+      .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 1, 1, 0, 0}, seriesPlaneNumberZCT);
+  }
+
+  /**
+   * Test more than one channel.
+   */
+  @Test
+  public void testMultiC() throws Exception {
+    input = fake("sizeC", "2");
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+
+    // Check dimensions and block size
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 1, 2, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{512, 512, 1, 1, 1}, da.getBlockSize());
+
+    // Check C 0 special pixels
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[]{0, 0, 0, 0, 0})
+      .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    // Check C 1 special pixels
+    tile = z.readBlock("/0/0", da, new long[]{0, 0, 0, 1, 0})
+      .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 1, 0, 1, 0}, seriesPlaneNumberZCT);
+  }
+
+  /**
+   * Test more than one timepoint.
+   */
+  @Test
+  public void testMultiT() throws Exception {
+    input = fake("sizeT", "2");
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+
+    // Check dimensions and block size
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertArrayEquals(new long[]{512, 512, 1, 1, 2}, da.getDimensions());
+    assertArrayEquals(new int[]{512, 512, 1, 1, 1}, da.getBlockSize());
+
+    // Check T 0 special pixels
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[]{0, 0, 0, 0, 0})
+      .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+    // Check T 1 special pixels
+    tile = z.readBlock("/0/0", da, new long[]{0, 0, 0, 0, 1})
+      .toByteBuffer();
+    seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 1, 0, 0, 1}, seriesPlaneNumberZCT);
+  }
+
+  /**
+   * Test pixel type preservation.
+   *
+   * @param type string representation of Bio-Formats pixel type
+   * @param n5Type expected corresponding N5 data type
+   */
+  @ParameterizedTest
+  @MethodSource("getPixelTypes")
+  public void testPixelType(String type, DataType n5Type) throws Exception {
+    input = fake("pixelType", type);
+    assertTool();
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+
+    // Check series dimensions and special pixels
+    DatasetAttributes da = z.getDatasetAttributes("/0/0");
+    assertEquals(n5Type, da.getDataType());
+    assertArrayEquals(new long[]{512, 512, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{512, 512, 1, 1, 1}, da.getBlockSize());
+    ByteBuffer tile = z.readBlock("/0/0", da, new long[]{0, 0, 0, 0, 0})
+      .toByteBuffer();
+    int[] seriesPlaneNumberZCT = FakeReader.readSpecialPixels(tile.array());
+    assertArrayEquals(new int[]{0, 0, 0, 0, 0}, seriesPlaneNumberZCT);
+  }
+
+  /**
+   * @return pairs of pixel type strings and N5 data types
+   */
+  static Stream<Arguments> getPixelTypes() {
+    return Stream.of(
+      Arguments.of("float", DataType.FLOAT32),
+      Arguments.of("double", DataType.FLOAT64),
+      Arguments.of("uint32", DataType.UINT32),
+      Arguments.of("int32", DataType.INT32)
+    );
+  }
+
+  /**
+   * Test that there are no edge effects when tiles do not divide evenly
+   * and downsampling.
+   */
+  @Test
+  public void testDownsampleEdgeEffectsUInt8() throws Exception {
+    input = fake("sizeX", "60", "sizeY", "300");
+    assertTool("-w", "25", "-h", "75");
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+
+    // Check series dimensions
+    DatasetAttributes da = z.getDatasetAttributes("/0/1");
+    assertArrayEquals(new long[]{30, 150, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{25, 75, 1, 1, 1}, da.getBlockSize());
+    ByteBuffer tile = z.readBlock("/0/1", da, new long[]{1, 0, 0, 0, 0})
+      .toByteBuffer();
+    // Last row first pixel should be the 2x2 downsampled value;
+    // test will break if the downsampling algorithm changes
+    assertEquals(50, tile.get(75 * 4));
+  }
+
+  /**
+   * Test that there are no edge effects when tiles do not divide evenly
+   * and downsampling.
+   */
+  @Test
+  public void testDownsampleEdgeEffectsUInt16() throws Exception {
+    input = fake("sizeX", "60", "sizeY", "300", "pixelType", "uint16");
+    assertTool("-w", "25", "-h", "75");
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+
+    // Check series dimensions
+    DatasetAttributes da = z.getDatasetAttributes("/0/1");
+    assertEquals(DataType.UINT16, da.getDataType());
+    assertArrayEquals(new long[]{30, 150, 1, 1, 1}, da.getDimensions());
+    assertArrayEquals(new int[]{25, 75, 1, 1, 1}, da.getBlockSize());
+    ShortBuffer tile = z.readBlock("/0/1", da, new long[]{1, 0, 0, 0, 0})
+      .toByteBuffer().asShortBuffer();
+    // Last row first pixel should be the 2x2 downsampled value;
+    // test will break if the downsampling algorithm changes
+    assertEquals(50, tile.get(75 * 4));
+  }
+
+  /**
+   * Test that original metadata is saved.
+   */
+  @Test
+  public void testOriginalMetadata() throws Exception {
+    Map<String, String> originalMetadata = new HashMap<String, String>();
+    originalMetadata.put("key1", "value1");
+    originalMetadata.put("key2", "value2");
+
+    input = fake(null, null, originalMetadata);
+    assertTool();
+    Path omexml = output.resolve("METADATA.ome.xml");
+    StringBuilder xml = new StringBuilder();
+    Files.lines(omexml).forEach(v -> xml.append(v));
+
+    OMEXMLService service =
+      new ServiceFactory().getInstance(OMEXMLService.class);
+    OMEXMLMetadata retrieve =
+      (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
+    Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
+    assertEquals(originalMetadata.size(), convertedMetadata.size());
+    for (String key : originalMetadata.keySet()) {
+      assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
+    }
+  }
+
+  /**
+   * Test that execution fails if the output directory already exists and the
+   * <code>--overwrite</code> option has not been supplied.
+   */
+  @Test
+  public void testFailIfNoOverwrite() throws IOException {
+    input = fake();
+    Files.createDirectory(output);
+    assertThrows(ExecutionException.class, () -> {
+      assertTool();
+    });
+  }
+
+  /**
+   * Test that execution succeeds if the output directory already exists and
+   * the <code>--overwrite</code> option has been supplied.
+   */
+  @Test
+  public void testOverwrite() throws IOException {
+    input = fake();
+    Files.createDirectory(output);
+    assertTool("--overwrite");
+  }
+
+  /**
+   * Test that appropriate metadata is written for each downsampling type.
+   *
+   * @param type downsampling type
+   */
+  @ParameterizedTest
+  @EnumSource(Downsampling.class)
+  public void testDownsampleTypes(Downsampling type) throws IOException {
+    input = fake();
+    assertTool("--downsample-type", type.toString());
+
+    N5Reader z =
+      new N5FSReader(output.resolve("data.n5").toString());
+    List<Map<String, Object>> multiscales =
+      z.getAttribute("/0", "multiscales", List.class);
+    assertEquals(1, multiscales.size());
+    Map<String, Object> multiscale = multiscales.get(0);
+    assertEquals("0.2", multiscale.get("version"));
+
+    Map<String, String> metadata =
+      (Map<String, String>) multiscale.get("metadata");
+    assertNotNull(metadata);
+
+    String version = metadata.get("version");
+    String method = metadata.get("method");
+    assertNotNull(version);
+    assertNotNull(method);
+
+    if (type != Downsampling.SIMPLE) {
+      assertEquals(type.getName(), multiscale.get("type"));
+      assertEquals(Core.VERSION, version);
+      assertEquals("org.opencv.imgproc.Imgproc." +
+        (type == Downsampling.GAUSSIAN ? "pyrDown" : "resize"), method);
+    }
+    else {
+      assertEquals("Bio-Formats " + FormatTools.VERSION, version);
+      assertEquals("loci.common.image.SimpleImageScaler", method);
+    }
+  }
+
+}


### PR DESCRIPTION
@keeneyetech/backend 

## Background/Issue

This branch aims to restore the N5 writer back into bioformats2n5 which was removed on the `0.3.0-rc1` version of the upstream project. What we wanted is to be able to use bioformats2n5 exactly in the same way (at worst changing/adding flags in command line) as we did in <0.3.0 versions.

## Proposal

I started by adding back the N5 dependency, and restoring the code by hand from the `0.2.6` version. In order to maintain the possible usage as it was intended for +0.3.0 versions, I restored the `file_type` flag with default value `zarr`. This means that if we want to use bioformats2n5 as it was in `0.2.6` we need to pass  the flag `--file_type n5` as well as the `-c lz4` flag if we want to use LZ4 compression. 

*Known limitations if any*

*Next steps if any*

## Review points

- [X]  ̶C̶h̶a̶n̶g̶e̶l̶o̶g̶ Readme is c̶o̶m̶p̶l̶e̶t̶e̶d̶ updated
- [X] Code is covered by unit tests if applicable
- [X] Implementation was tested by the developer
