### PR TITLE
add nopix option to convert

### DIFF
--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -344,6 +344,12 @@ public class Converter implements Callable<Void> {
   private volatile boolean noHCS = false;
 
   @Option(
+    names = "--noPix",
+    description = "Save only metadata no pixel data"
+  )
+  private volatile boolean noPix = true;
+
+  @Option(
           names = "--no-root-group",
           description = "Turn off creation of root group and corresponding " +
                         "metadata [Will break compatibility with raw2ometiff]"
@@ -589,15 +595,15 @@ public class Converter implements Callable<Void> {
       if (!noHCS) {
         scaleFormatString = "%d/%d/%d/%d";
       }
-
-      for (Integer index : seriesList) {
-        try {
-          write(index);
-        }
-        catch (Throwable t) {
-          LOGGER.error("Error while writing series {}", index, t);
-          unwrapException(t);
-          return;
+      if (!noPix) {
+        for (Integer index : seriesList) {
+          try {
+            write(index);
+          } catch (Throwable t) {
+            LOGGER.error("Error while writing series {}", index, t);
+            unwrapException(t);
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
This PR adds an option to create only the OME-XML metadata without pixel data.
as requested in https://github.com/keeneyetech/bioformats2n5/issues/2
This makes it possible to get the metadata for all series in a file in a first step before gettin the relevant data in a 2nd step.