### PR TITLE
Update bio-formats to 6.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'ai.keeneye'
-version = '0.3.2-SNAPSHOT'
+version = '0.4.0'
 
 mainClassName = 'ai.keeneye.bioformats2n5.Converter'
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'ai.keeneye'
-version = '0.3.1-SNAPSHOT'
+version = '0.3.2-SNAPSHOT'
 
 mainClassName = 'ai.keeneye.bioformats2n5.Converter'
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'ome:formats-gpl:6.5.1'
+    implementation 'ome:formats-gpl:6.7.0'
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'com.univocity:univocity-parsers:2.8.4'
     implementation 'com.bc.zarr:jzarr:0.3.3-gs-SNAPSHOT'

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -487,7 +487,8 @@ public class Converter implements Callable<Void> {
         memoizer.setMetadataOptions(options);
       }
 
-      memoizer.setOriginalMetadataPopulated(true);
+      // set this flag to true if original metadata is required
+      memoizer.setOriginalMetadataPopulated(false);
       memoizer.setFlattenedResolutions(false);
       memoizer.setMetadataFiltered(true);
       memoizer.setMetadataStore(createMetadata());

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -17,7 +17,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Hashtable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -25,11 +25,16 @@ import java.util.stream.Stream;
 import ai.keeneye.bioformats2n5.Converter;
 import ai.keeneye.bioformats2n5.Downsampling;
 import loci.common.LogbackTools;
-import loci.common.services.ServiceFactory;
+
 import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;
-import loci.formats.ome.OMEXMLMetadata;
-import loci.formats.services.OMEXMLService;
+
+// imports for originalMetadata tests
+// import java.util.Hashtable;
+// import loci.common.services.ServiceFactory;
+// import loci.formats.ome.OMEXMLMetadata;
+// import loci.formats.services.OMEXMLService;
+
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import picocli.CommandLine;

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -496,11 +496,11 @@ public class N5Test {
     assertEquals(50, tile.get(75 * 4));
   }
 
+  // restore this test if original metadata is required
   /**
    * Test that original metadata is saved.
    */
-  /** retore this test if original metadata is required
-  @Test
+  /* @Test
   public void testOriginalMetadata() throws Exception {
     Map<String, String> originalMetadata = new HashMap<String, String>();
     originalMetadata.put("key1", "value1");

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -497,7 +497,7 @@ public class N5Test {
   }
 
   // restore this test if original metadata is required
-  /**
+  /*
    * Test that original metadata is saved.
    */
   /* @Test

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -494,6 +494,7 @@ public class N5Test {
   /**
    * Test that original metadata is saved.
    */
+  /** retore this test if original metadata is required
   @Test
   public void testOriginalMetadata() throws Exception {
     Map<String, String> originalMetadata = new HashMap<String, String>();
@@ -515,7 +516,7 @@ public class N5Test {
     for (String key : originalMetadata.keySet()) {
       assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
     }
-  }
+  } */
 
   /**
    * Test that execution fails if the output directory already exists and the

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -17,7 +17,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -33,7 +32,11 @@ import loci.common.LogbackTools;
 import loci.common.services.ServiceFactory;
 import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;
-import loci.formats.ome.OMEXMLMetadata;
+
+// imports for originalMetaData tests
+// import java.util.Hashtable;
+// import loci.formats.ome.OMEXMLMetadata;
+
 import loci.formats.services.OMEXMLService;
 import ome.xml.model.OME;
 import ome.xml.model.Pixels;

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -674,7 +674,7 @@ public class ZarrTest {
   }
 
   //Restore this test if original metadata is required
-  /**
+  /*
    * Test that original metadata is saved.
    */
 /*

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -673,6 +673,7 @@ public class ZarrTest {
   /**
    * Test that original metadata is saved.
    */
+/**  Restore this test if original metadata is required
   @Test
   public void testOriginalMetadata() throws Exception {
     Map<String, String> originalMetadata = new HashMap<String, String>();
@@ -694,7 +695,7 @@ public class ZarrTest {
     for (String key : originalMetadata.keySet()) {
       assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
     }
-  }
+  } */
 
   /**
    * Test that execution fails if the output directory already exists and the

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -673,32 +673,34 @@ public class ZarrTest {
     assertEquals(50, tile[75 * 4]);
   }
 
+  //Restore this test if original metadata is required
   /**
    * Test that original metadata is saved.
    */
-/**  Restore this test if original metadata is required
-  @Test
-  public void testOriginalMetadata() throws Exception {
-    Map<String, String> originalMetadata = new HashMap<String, String>();
-    originalMetadata.put("key1", "value1");
-    originalMetadata.put("key2", "value2");
+/*
+ @Test
+ public void testOriginalMetadata() throws Exception {
+   Map<String, String> originalMetadata = new HashMap<String, String>();
+   originalMetadata.put("key1", "value1");
+   originalMetadata.put("key2", "value2");
 
-    input = fake(null, null, originalMetadata);
-    assertTool();
-    Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
-    StringBuilder xml = new StringBuilder();
-    Files.lines(omexml).forEach(v -> xml.append(v));
+   input = fake(null, null, originalMetadata);
+   assertTool();
+   Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
+   StringBuilder xml = new StringBuilder();
+   Files.lines(omexml).forEach(v -> xml.append(v));
 
-    OMEXMLService service =
-      new ServiceFactory().getInstance(OMEXMLService.class);
-    OMEXMLMetadata retrieve =
-      (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
-    Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
-    assertEquals(originalMetadata.size(), convertedMetadata.size());
-    for (String key : originalMetadata.keySet()) {
-      assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
-    }
-  } */
+   OMEXMLService service =
+     new ServiceFactory().getInstance(OMEXMLService.class);
+   OMEXMLMetadata retrieve =
+     (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
+   Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
+   assertEquals(originalMetadata.size(), convertedMetadata.size());
+   for (String key : originalMetadata.keySet()) {
+     assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
+   }
+ }
+*/
 
   /**
    * Test that execution fails if the output directory already exists and the


### PR DESCRIPTION
This PR updates bio-formats to 6.7 and also suppresses the reading of the original metadata which we do not currently  use.