### PR TITLE
Write file format to json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'ai.keeneye'
-version = '0.4.0'
+version = '0.5.0'
 
 mainClassName = 'ai.keeneye.bioformats2n5.Converter'
 sourceCompatibility = 1.8

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -37,7 +37,10 @@
 
     <!-- Checks for Size Violations.                    -->
     <!-- See https://checkstyle.org/config_sizes.html -->
-    <module name="FileLength"/>
+    <module name="FileLength">
+        <property name="max" value="4000"/>
+    </module>
+
     <module name="LineLength">
       <property name="fileExtensions" value="java"/>
     </module>

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -470,6 +470,8 @@ public class Converter implements Callable<Void> {
       maxWorkers = 1;
     }
 
+    String format = "";
+
 
     // Now with our found type instantiate our queue of readers for use
     // during conversion
@@ -518,23 +520,7 @@ public class Converter implements Callable<Void> {
       }
       readers.add(separator);
 
-      if (noPix) {
-        // write the file format string to json
-        String format = reader.getFormat();
-        JsonFactory factory = new JsonFactory();
-        // Create JsonGenerator
-        if (!Files.exists(outputPath)) {
-          Files.createDirectories(outputPath);
-        }
-        String jpath = outputPath + "/format.json";
-        File f = new File(jpath);
-        JsonGenerator generator = factory.createGenerator(f, JsonEncoding.UTF8);
-        generator.writeStartObject(); // Start with left brace i.e. {
-        // Add string field
-        generator.writeStringField("format", format);
-        generator.writeEndObject(); // End with right brace i.e }
-        generator.close();
-      }
+      format = reader.getFormat();
 
       // stop after the first reader if only one tile in the image
       if (reader.getOptimalTileWidth() == reader.getSizeX()  && reader.getOptimalTileHeight() == reader.getSizeY()) {
@@ -620,6 +606,20 @@ public class Converter implements Callable<Void> {
         }
         Path omexmlFile = metadataPath.resolve(METADATA_FILE);
         Files.write(omexmlFile, xml.getBytes(Constants.ENCODING));
+
+        if (noPix) {
+          // write the file format string to json
+          JsonFactory factory = new JsonFactory();
+          // Create JsonGenerator
+          String jpath = metadataPath + "/format.json";
+          File f = new File(jpath);
+          JsonGenerator generator = factory.createGenerator(f, JsonEncoding.UTF8);
+          generator.writeStartObject(); // Start with left brace i.e. {
+          // Add string field
+          generator.writeStringField("format", format);
+          generator.writeEndObject(); // End with right brace i.e }
+          generator.close();
+        }
       }
       catch (ServiceException se) {
         LOGGER.error("Could not retrieve OME-XML", se);

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -519,7 +519,8 @@ public class Converter implements Callable<Void> {
 
       // stop after the first reader if only one tile in the image
       if (reader.getOptimalTileWidth() == reader.getSizeX()
-        && reader.getOptimalTileHeight() == reader.getSizeY()) {
+        && reader.getOptimalTileHeight() == reader.getSizeY())
+      {
         break;
       }
     }

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -393,6 +393,8 @@ public class Converter implements Callable<Void> {
   private List<HCSIndex> hcsIndexes = new ArrayList<HCSIndex>();
 
   private String format = "";
+  private int optimalTileWidth = 512;
+  private int optimalTileHeight = 512;
 
   @Override
   public Void call() throws Exception {
@@ -619,6 +621,8 @@ public class Converter implements Callable<Void> {
           generator.writeStartObject(); // Start with left brace i.e. {
           // Add string field
           generator.writeStringField("format", format);
+          generator.writeNumberField("tileWidth", optimalTileWidth);
+          generator.writeNumberField("tileHeight", optimalTileHeight);
           generator.writeEndObject(); // End with right brace i.e }
           generator.close();
         }
@@ -1983,6 +1987,8 @@ public class Converter implements Callable<Void> {
     try {
       imageReader.setId(inputPath.toString());
       format = imageReader.getFormat();
+      optimalTileWidth = imageReader.getOptimalTileWidth();
+      optimalTileHeight = imageReader.getOptimalTileHeight();
       imageReader.getCoreMetadataList();
       return imageReader.getReader().getClass();
     }

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -392,6 +392,8 @@ public class Converter implements Callable<Void> {
 
   private List<HCSIndex> hcsIndexes = new ArrayList<HCSIndex>();
 
+  private String format = "";
+
   @Override
   public Void call() throws Exception {
     if (printVersion) {
@@ -466,8 +468,6 @@ public class Converter implements Callable<Void> {
       maxWorkers = 1;
     }
 
-    String format = "";
-
     // Now with our found type instantiate our queue of readers for use
     // during conversion
     for (int i=0; i < maxWorkers; i++) {
@@ -514,15 +514,6 @@ public class Converter implements Callable<Void> {
         ((MiraxReader) reader).setTileCache(tileCache);
       }
       readers.add(separator);
-
-      format = reader.getFormat();
-
-      // stop after the first reader if only one tile in the image
-      if (reader.getOptimalTileWidth() == reader.getSizeX()
-        && reader.getOptimalTileHeight() == reader.getSizeY())
-      {
-        break;
-      }
     }
 
     // Finally, perform conversion on all series
@@ -1981,6 +1972,8 @@ public class Converter implements Callable<Void> {
     ImageReader imageReader = new ImageReader(readerClasses);
     try {
       imageReader.setId(inputPath.toString());
+      format = imageReader.getFormat();
+      imageReader.getCoreMetadataList();
       return imageReader.getReader().getClass();
     }
     finally {

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -6,10 +6,7 @@
  * missing please request a copy by contacting info@glencoesoftware.com
  */
 package ai.keeneye.bioformats2n5;
-
-import java.io.DataOutput;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -33,7 +30,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
-
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -471,7 +467,6 @@ public class Converter implements Callable<Void> {
     }
 
     String format = "";
-
 
     // Now with our found type instantiate our queue of readers for use
     // during conversion

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -518,7 +518,8 @@ public class Converter implements Callable<Void> {
       format = reader.getFormat();
 
       // stop after the first reader if only one tile in the image
-      if (reader.getOptimalTileWidth() == reader.getSizeX()  && reader.getOptimalTileHeight() == reader.getSizeY()) {
+      if (reader.getOptimalTileWidth() == reader.getSizeX()
+        && reader.getOptimalTileHeight() == reader.getSizeY()) {
         break;
       }
     }
@@ -608,7 +609,8 @@ public class Converter implements Callable<Void> {
           // Create JsonGenerator
           String jpath = metadataPath + "/format.json";
           File f = new File(jpath);
-          JsonGenerator generator = factory.createGenerator(f, JsonEncoding.UTF8);
+          JsonGenerator generator
+            = factory.createGenerator(f, JsonEncoding.UTF8);
           generator.writeStartObject(); // Start with left brace i.e. {
           // Add string field
           generator.writeStringField("format", format);

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -107,7 +107,6 @@ public class N5Test {
         assertTrue(Files.exists(output.resolve("data.n5")));
         assertTrue(Files.exists(output.resolve("format.json")));
       }
-      }
       assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
     }
     catch (RuntimeException rt) {

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -105,7 +105,7 @@ public class N5Test {
       }
       else {
         assertTrue(Files.exists(output.resolve("data.n5")));
-        assertTrue(Files.exists(output.resolve("format.json")));
+        assertFalse(Files.exists(output.resolve("format.json")));
       }
       assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
     }

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -101,9 +101,12 @@ public class N5Test {
       CommandLine.call(converter, args.toArray(new String[]{}));
       if (metadataOnly) {
         assertFalse(Files.exists(output.resolve("data.n5")));
+        assertTrue(Files.exists(output.resolve("format.json")));
       }
       else {
         assertTrue(Files.exists(output.resolve("data.n5")));
+        assertTrue(Files.exists(output.resolve("format.json")));
+      }
       }
       assertTrue(Files.exists(output.resolve("METADATA.ome.xml")));
     }


### PR DESCRIPTION
THis PR writes the file format to a json file when the --no-pixel-data flag is used to indicate metadata only is written.
As it uses this flag I have also ttempted to address some remarks in https://github.com/keeneyetech/bioformats2n5/pull/3 , about performance, 
by reducing the no of workers to 1 when this flag is set - so that only a single worker is instantiated.
The optimalTileSize is also returned in the same json file.