### PR TITLE
Restore original metadata #KEP-862 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'ai.keeneye'
-version = '0.5.0'
+version = '0.6.0'
 
 mainClassName = 'ai.keeneye.bioformats2n5.Converter'
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'ome:formats-gpl:6.7.0'
+    implementation 'ome:formats-gpl:6.8.1'
     implementation 'info.picocli:picocli:4.2.0'
     implementation 'com.univocity:univocity-parsers:2.8.4'
     implementation 'com.bc.zarr:jzarr:0.3.3-gs-SNAPSHOT'

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -505,7 +505,7 @@ public class Converter implements Callable<Void> {
       }
 
       // set this flag to true if original metadata is required
-      memoizer.setOriginalMetadataPopulated(false);
+      memoizer.setOriginalMetadataPopulated(true);
       memoizer.setFlattenedResolutions(false);
       memoizer.setMetadataFiltered(true);
       memoizer.setMetadataStore(createMetadata());

--- a/src/main/java/ai/keeneye/bioformats2n5/Converter.java
+++ b/src/main/java/ai/keeneye/bioformats2n5/Converter.java
@@ -1989,7 +1989,6 @@ public class Converter implements Callable<Void> {
       format = imageReader.getFormat();
       optimalTileWidth = imageReader.getOptimalTileWidth();
       optimalTileHeight = imageReader.getOptimalTileHeight();
-      imageReader.getCoreMetadataList();
       return imageReader.getReader().getClass();
     }
     finally {


### PR DESCRIPTION
In an earlier PR https://github.com/keeneyetech/bioformats2n5/pull/4 the writing of the Original Metadata to the OME-XML was disabled in the interest of performance.

This MR restores it as it makes it possible to discriminate .ndpi files on the basis of compression type.
An apparently "stray" line of code is also removed
The version number is also bumped as is the bio-formats version (to the latest available)