### PR TITLE
restore Original metadata tests #KEP-887

### DIFF
--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2019 Glencoe Software, Inc. All rights reserved.
+ * <p>
+ * This software is distributed under the terms described by the LICENSE.txt
+ * file you can find at the root of the distribution bundle.  If the file is
+ * missing please request a copy by contacting info@glencoesoftware.com
+ */
 package ai.keeneye.bioformats2n5.test;
 
 import java.io.File;
@@ -495,12 +502,13 @@ public class N5Test {
     assertEquals(DataType.UINT16, da.getDataType());
     assertArrayEquals(new long[]{30, 150, 1, 1, 1}, da.getDimensions());
     assertArrayEquals(new int[]{25, 75, 1, 1, 1}, da.getBlockSize());
-    ShortBuffer tile = z.readBlock("/0/1", da, new long[]{1, 0, 0, 0, 0}).toByteBuffer().asShortBuffer();
+    ShortBuffer tile = z.readBlock("/0/1", da, new long[]{1, 0, 0, 0, 0})
+      .toByteBuffer().asShortBuffer();
     // Last row first pixel should be the 2x2 downsampled value;
     // test will break if the downsampling algorithm changes
     assertEquals(50, tile.get(75 * 4));
   }
-
+  
   /**
    * Test that original metadata is saved.
    */
@@ -509,6 +517,7 @@ public class N5Test {
     Map<String, String> originalMetadata = new HashMap<String, String>();
     originalMetadata.put("key1", "value1");
     originalMetadata.put("key2", "value2");
+
     input = fake(null, null, originalMetadata);
     assertTool();
     Path omexml = output.resolve("METADATA.ome.xml");

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) 2019 Glencoe Software, Inc. All rights reserved.
- * <p>
- * This software is distributed under the terms described by the LICENSE.txt
- * file you can find at the root of the distribution bundle.  If the file is
- * missing please request a copy by contacting info@glencoesoftware.com
- */
 package ai.keeneye.bioformats2n5.test;
 
 import java.io.File;
@@ -502,13 +495,12 @@ public class N5Test {
     assertEquals(DataType.UINT16, da.getDataType());
     assertArrayEquals(new long[]{30, 150, 1, 1, 1}, da.getDimensions());
     assertArrayEquals(new int[]{25, 75, 1, 1, 1}, da.getBlockSize());
-    ShortBuffer tile = z.readBlock("/0/1", da, new long[]{1, 0, 0, 0, 0})
-      .toByteBuffer().asShortBuffer();
+    ShortBuffer tile = z.readBlock("/0/1", da, new long[]{1, 0, 0, 0, 0}).toByteBuffer().asShortBuffer();
     // Last row first pixel should be the 2x2 downsampled value;
     // test will break if the downsampling algorithm changes
     assertEquals(50, tile.get(75 * 4));
   }
-  
+
   /**
    * Test that original metadata is saved.
    */
@@ -517,7 +509,6 @@ public class N5Test {
     Map<String, String> originalMetadata = new HashMap<String, String>();
     originalMetadata.put("key1", "value1");
     originalMetadata.put("key2", "value2");
-
     input = fake(null, null, originalMetadata);
     assertTool();
     Path omexml = output.resolve("METADATA.ome.xml");

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -523,7 +523,6 @@ public class N5Test {
     Path omexml = output.resolve("METADATA.ome.xml");
     StringBuilder xml = new StringBuilder();
     Files.lines(omexml).forEach(v -> xml.append(v));
-
     OMEXMLService service =
       new ServiceFactory().getInstance(OMEXMLService.class);
     OMEXMLMetadata retrieve =

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -508,7 +508,7 @@ public class N5Test {
     // test will break if the downsampling algorithm changes
     assertEquals(50, tile.get(75 * 4));
   }
-  
+
   /**
    * Test that original metadata is saved.
    */
@@ -517,7 +517,6 @@ public class N5Test {
     Map<String, String> originalMetadata = new HashMap<String, String>();
     originalMetadata.put("key1", "value1");
     originalMetadata.put("key2", "value2");
-
     input = fake(null, null, originalMetadata);
     assertTool();
     Path omexml = output.resolve("METADATA.ome.xml");

--- a/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/N5Test.java
@@ -30,10 +30,10 @@ import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;
 
 // imports for originalMetadata tests
-// import java.util.Hashtable;
-// import loci.common.services.ServiceFactory;
-// import loci.formats.ome.OMEXMLMetadata;
-// import loci.formats.services.OMEXMLService;
+import java.util.Hashtable;
+import loci.common.services.ServiceFactory;
+import loci.formats.ome.OMEXMLMetadata;
+import loci.formats.services.OMEXMLService;
 
 import org.janelia.saalfeldlab.n5.N5FSReader;
 import org.janelia.saalfeldlab.n5.N5Reader;
@@ -508,12 +508,11 @@ public class N5Test {
     // test will break if the downsampling algorithm changes
     assertEquals(50, tile.get(75 * 4));
   }
-
-  // restore this test if original metadata is required
-  /*
+  
+  /**
    * Test that original metadata is saved.
    */
-  /* @Test
+  @Test
   public void testOriginalMetadata() throws Exception {
     Map<String, String> originalMetadata = new HashMap<String, String>();
     originalMetadata.put("key1", "value1");
@@ -534,7 +533,7 @@ public class N5Test {
     for (String key : originalMetadata.keySet()) {
       assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
     }
-  } */
+  }
 
   /**
    * Test that execution fails if the output directory already exists and the

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -673,30 +673,30 @@ public class ZarrTest {
     assertEquals(50, tile[75 * 4]);
   }
 
-  /**
-   * Test that original metadata is saved.
-   */
- @Test
- public void testOriginalMetadata() throws Exception {
-   Map<String, String> originalMetadata = new HashMap<String, String>();
-   originalMetadata.put("key1", "value1");
-   originalMetadata.put("key2", "value2");
+    /**
+     * Test that original metadata is saved.
+     */
+   @Test
+   public void testOriginalMetadata() throws Exception {
+     Map<String, String> originalMetadata = new HashMap<String, String>();
+     originalMetadata.put("key1", "value1");
+     originalMetadata.put("key2", "value2");
 
-   input = fake(null, null, originalMetadata);
-   assertTool();
-   Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
-   StringBuilder xml = new StringBuilder();
-   Files.lines(omexml).forEach(v -> xml.append(v));
-   OMEXMLService service =
-     new ServiceFactory().getInstance(OMEXMLService.class);
-   OMEXMLMetadata retrieve =
-     (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
-   Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
-   assertEquals(originalMetadata.size(), convertedMetadata.size());
-   for (String key : originalMetadata.keySet()) {
-     assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
+     input = fake(null, null, originalMetadata);
+     assertTool();
+     Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
+     StringBuilder xml = new StringBuilder();
+     Files.lines(omexml).forEach(v -> xml.append(v));
+     OMEXMLService service =
+       new ServiceFactory().getInstance(OMEXMLService.class);
+     OMEXMLMetadata retrieve =
+       (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
+     Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
+     assertEquals(originalMetadata.size(), convertedMetadata.size());
+     for (String key : originalMetadata.keySet()) {
+       assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
+     }
    }
- }
 
   /**
    * Test that execution fails if the output directory already exists and the

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -674,29 +674,29 @@ public class ZarrTest {
   }
 
   /**
-   * * Test that original metadata is saved.
-   * */
-   @Test
-   public void testOriginalMetadata() throws Exception {
-     Map<String, String> originalMetadata = new HashMap<String, String>();
-     originalMetadata.put("key1", "value1");
-     originalMetadata.put("key2", "value2");
+   *  Test that original metadata is saved.
+   */
+  @Test
+  public void testOriginalMetadata() throws Exception {
+    Map<String, String> originalMetadata = new HashMap<String, String>();
+    originalMetadata.put("key1", "value1");
+    originalMetadata.put("key2", "value2");
 
-     input = fake(null, null, originalMetadata);
-     assertTool();
-     Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
-     StringBuilder xml = new StringBuilder();
-     Files.lines(omexml).forEach(v -> xml.append(v));
-     OMEXMLService service =
-       new ServiceFactory().getInstance(OMEXMLService.class);
-     OMEXMLMetadata retrieve =
-       (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
-     Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
-     assertEquals(originalMetadata.size(), convertedMetadata.size());
-     for (String key : originalMetadata.keySet()) {
-       assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
-     }
-   }
+    input = fake(null, null, originalMetadata);
+    assertTool();
+    Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
+    StringBuilder xml = new StringBuilder();
+    Files.lines(omexml).forEach(v -> xml.append(v));
+    OMEXMLService service =
+      new ServiceFactory().getInstance(OMEXMLService.class);
+    OMEXMLMetadata retrieve =
+      (OMEXMLMetadata) service.createOMEXMLMetadata(xml.toString());
+    Hashtable convertedMetadata = service.getOriginalMetadata(retrieve);
+    assertEquals(originalMetadata.size(), convertedMetadata.size());
+    for (String key : originalMetadata.keySet()) {
+      assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
+    }
+  }
 
   /**
    * Test that execution fails if the output directory already exists and the

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -673,9 +673,9 @@ public class ZarrTest {
     assertEquals(50, tile[75 * 4]);
   }
 
-    /**
-     * Test that original metadata is saved.
-     */
+  /**
+   * * Test that original metadata is saved.
+   * */
    @Test
    public void testOriginalMetadata() throws Exception {
      Map<String, String> originalMetadata = new HashMap<String, String>();

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -34,8 +34,8 @@ import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;
 
 // imports for originalMetaData tests
-// import java.util.Hashtable;
-// import loci.formats.ome.OMEXMLMetadata;
+import java.util.Hashtable;
+import loci.formats.ome.OMEXMLMetadata;
 
 import loci.formats.services.OMEXMLService;
 import ome.xml.model.OME;
@@ -673,11 +673,9 @@ public class ZarrTest {
     assertEquals(50, tile[75 * 4]);
   }
 
-  //Restore this test if original metadata is required
-  /*
+  /**
    * Test that original metadata is saved.
    */
-/*
  @Test
  public void testOriginalMetadata() throws Exception {
    Map<String, String> originalMetadata = new HashMap<String, String>();
@@ -689,7 +687,6 @@ public class ZarrTest {
    Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
    StringBuilder xml = new StringBuilder();
    Files.lines(omexml).forEach(v -> xml.append(v));
-
    OMEXMLService service =
      new ServiceFactory().getInstance(OMEXMLService.class);
    OMEXMLMetadata retrieve =
@@ -700,7 +697,6 @@ public class ZarrTest {
      assertEquals(originalMetadata.get(key), convertedMetadata.get(key));
    }
  }
-*/
 
   /**
    * Test that execution fails if the output directory already exists and the

--- a/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
+++ b/src/test/java/ai/keeneye/bioformats2n5/test/ZarrTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -32,11 +33,7 @@ import loci.common.LogbackTools;
 import loci.common.services.ServiceFactory;
 import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;
-
-// imports for originalMetaData tests
-import java.util.Hashtable;
 import loci.formats.ome.OMEXMLMetadata;
-
 import loci.formats.services.OMEXMLService;
 import ome.xml.model.OME;
 import ome.xml.model.Pixels;
@@ -674,7 +671,7 @@ public class ZarrTest {
   }
 
   /**
-   *  Test that original metadata is saved.
+   * Test that original metadata is saved.
    */
   @Test
   public void testOriginalMetadata() throws Exception {
@@ -687,6 +684,7 @@ public class ZarrTest {
     Path omexml = output.resolve("OME").resolve("METADATA.ome.xml");
     StringBuilder xml = new StringBuilder();
     Files.lines(omexml).forEach(v -> xml.append(v));
+
     OMEXMLService service =
       new ServiceFactory().getInstance(OMEXMLService.class);
     OMEXMLMetadata retrieve =


### PR DESCRIPTION
This changes in this MR restore the original metadata tests commented out in https://github.com/keeneyetech/bioformats2n5/pull/4
these are now needed as the reading of the original metadata was restored in https://github.com/keeneyetech/bioformats2n5/pull/6

@bench Re: your comments on https://github.com/keeneyetech/bioformats2n5/pull/4
these tests were commented out in case they needed to be restored as has just been found to be the case
